### PR TITLE
reset form bugfix

### DIFF
--- a/code/public/js/mcmap.js
+++ b/code/public/js/mcmap.js
@@ -82,6 +82,7 @@ function resetForm(formId) {
     // console.log('resetting form ' + formId);
     document.forms[formId].reset();
     $('#' + formId).find('textarea[name="comment"]').html('').val('');
+    $('#' + formId).find('input[name="id"]').val('');
     $('#' + formId).find('.is-invalid').removeClass('is-invalid');
 }
 


### PR DESCRIPTION
Fixed bug where input ID wouldn't reset when dropdown was reset, causing editing the last place instead of adding a new one, after editing a previous place